### PR TITLE
Add shrinking for PathBuf

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -421,10 +421,11 @@ impl Arbitrary for PathBuf {
         }
 
         // Add the canonicalized variant only if canonicalizing the path actually does something,
-        // making it (hopefully) smaller.
-        let canonicalized = self.canonicalize();
-        if canonicalized != self {
-            shrunk.push(canonicalized);
+        // making it (hopefully) smaller. Also, ignore canonicalization if canonicalization errors.
+        if let Ok(canonicalized) = self.canonicalize() {
+            if &canonicalized != self {
+                shrunk.push(canonicalized);
+            }
         }
 
         Box::new(shrunk.into_iter())

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -412,9 +412,23 @@ impl Arbitrary for PathBuf {
         p
     }
 
-    // I'm not sure how to shrink this.  Help appreciated!
-    // fn shrink(&self) -> Box<Iterator<Item=PathBuf>> {
-    // }
+    fn shrink(&self) -> Box<Iterator<Item=PathBuf>> {
+        let mut shrunk = Vec::new();
+
+        let mut popped = self.clone();
+        if popped.pop() {
+            shrunk.push(popped);
+        }
+
+        // Add the canonicalized variant only if canonicalizing the path actually does something,
+        // making it (hopefully) smaller.
+        let canonicalized = self.canonicalize();
+        if canonicalized != self {
+            shrunk.push(canonicalized);
+        }
+
+        Box::new(shrunk.into_iter())
+    }
 }
 
 impl Arbitrary for OsString {


### PR DESCRIPTION
This adds three different possible paths for shrinking a `PathBuf`:
1. `.pop()`-ing the top component off of the `PathBuf`. If `.pop()` returns true, then the "popped" path is considered a valid shrunken example.
2. Iterating and then collecting the iterated components into a new `PathBuf`. Iteration will do a small amount of normalization, as documented [here](https://doc.rust-lang.org/std/path/struct.Path.html#method.components). Admittedly `.components()` is not used in this patch but `.iter()` calls `.components()` under the hood.
3. Calling `.canonicalize()` on a `PathBuf`. If `.canonicalize()` returns `Ok` and the resulting canonicalized path is different from the given path, the canonicalized path is considered a valid shrunken example.